### PR TITLE
Added to new attributes for click highlight and folder collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Attributes of angular treeview are below.
 - node-id : each node's id.
 - node-label : each node's label.
 - node-children: each node's children.
+- node-toggleclick: when a node's label is clicked, toggle the folder
+- node-highlight:  turn click highlighting on and off
 
 Here is a simple example.
 
@@ -43,7 +45,9 @@ Here is a simple example.
 	data-tree-model="treedata"
 	data-node-id="id"
 	data-node-label="label"
-	data-node-children="children" >
+	data-node-children="children" 
+    data-node-toggleclick="true"
+    data-node-highlight="true" >
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Here is a simple example.
 	data-node-label="label"
 	data-node-children="children" 
     data-node-toggleclick="true"
-    data-node-highlight="true" >
+    data-node-highlight="true" 
+>
 </div>
 ```
 

--- a/angular.treeview.js
+++ b/angular.treeview.js
@@ -18,7 +18,10 @@
 		data-tree-model="roleList"
 		data-node-id="roleId"
 		data-node-label="roleName"
-		data-node-children="children" >
+		data-node-children="children" 
+        data-node-toggleclick="true"
+        data-node-highlight="false"
+		>
 	</div>
 */
 
@@ -43,6 +46,12 @@
 
 				//children
 				var nodeChildren = attrs.nodeChildren || 'children';
+
+				//node open/click on click
+                var nodeToggleClick = attrs.nodeToggleclick || 'false';
+
+                //node highlight on click
+                var nodeHighlightOnClick = attrs.nodeHighlight || 'true';
 
 				//tree template
 				var template =
@@ -81,8 +90,15 @@
 								scope[treeId].currentNode.selected = undefined;
 							}
 
-							//set highlight to selected node
-							selectedNode.selected = 'selected';
+                            //set highlight to selected node
+                            if (nodeHighlightOnClick == 'true') {
+                                selectedNode.selected = 'selected';
+                            }
+                            
+                            //set collapsed if collapsable on label click
+                            if (nodeToggleClick == 'true') {
+                                selectedNode.collapsed = !selectedNode.collapsed;
+                            }
 
 							//set currentNode
 							scope[treeId].currentNode = selectedNode;

--- a/angular.treeview.js
+++ b/angular.treeview.js
@@ -1,5 +1,5 @@
 /*
-	@license Angular Treeview version 0.1.6
+	@license Angular Treeview version 0.1.7
 	ⓒ 2013 AHN JAE-HA http://github.com/eu81273/angular.treeview
 	License: MIT
 

--- a/angular.treeview.min.js
+++ b/angular.treeview.min.js
@@ -1,9 +1,27 @@
 /*
-	@license Angular Treeview version 0.1.6
+	@license Angular Treeview version 0.1.7
 	ⓒ 2013 AHN JAE-HA http://github.com/eu81273/angular.treeview
 	License: MIT
-*/
 
-(function(f){f.module("angularTreeview",[]).directive("treeModel",function($compile){return{restrict:"A",link:function(b,h,c){var a=c.treeId,g=c.treeModel,e=c.nodeLabel||"label",d=c.nodeChildren||"children",e='<ul><li data-ng-repeat="node in '+g+'"><i class="collapsed" data-ng-show="node.'+d+'.length && node.collapsed" data-ng-click="'+a+'.selectNodeHead(node)"></i><i class="expanded" data-ng-show="node.'+d+'.length && !node.collapsed" data-ng-click="'+a+'.selectNodeHead(node)"></i><i class="normal" data-ng-hide="node.'+
-d+'.length"></i> <span data-ng-class="node.selected" data-ng-click="'+a+'.selectNodeLabel(node)">{{node.'+e+'}}</span><div data-ng-hide="node.collapsed" data-tree-id="'+a+'" data-tree-model="node.'+d+'" data-node-id='+(c.nodeId||"id")+" data-node-label="+e+" data-node-children="+d+"></div></li></ul>";a&&g&&(c.angularTreeview&&(b[a]=b[a]||{},b[a].selectNodeHead=b[a].selectNodeHead||function(a){a.collapsed=!a.collapsed},b[a].selectNodeLabel=b[a].selectNodeLabel||function(c){b[a].currentNode&&b[a].currentNode.selected&&
-(b[a].currentNode.selected=void 0);c.selected="selected";b[a].currentNode=c}),h.html('').append($compile(e)(b)))}}})})(angular);
+
+	[TREE attribute]
+	angular-treeview: the treeview directive
+	tree-id : each tree's unique id.
+	tree-model : the tree model on $scope.
+	node-id : each node's id
+	node-label : each node's label
+	node-children: each node's children
+
+	<div
+		data-angular-treeview="true"
+		data-tree-id="tree"
+		data-tree-model="roleList"
+		data-node-id="roleId"
+		data-node-label="roleName"
+		data-node-children="children" 
+        data-node-toggleclick="true"
+        data-node-highlight="false"
+		>
+	</div>
+*/
+(function(e){"use strict";e.module("angularTreeview",[]).directive("treeModel",["$compile",function(e){return{restrict:"A",link:function(d,l,a){var n=a.treeId,o=a.treeModel,t=a.nodeId||"id",c=a.nodeLabel||"label",i=a.nodeChildren||"children",s=a.nodeToggleclick||"false",r=a.nodeHighlight||"true",u='<ul><li data-ng-repeat="node in '+o+'">'+'<i class="collapsed" data-ng-show="node.'+i+'.length && node.collapsed" data-ng-click="'+n+'.selectNodeHead(node)"></i>'+'<i class="expanded" data-ng-show="node.'+i+'.length && !node.collapsed" data-ng-click="'+n+'.selectNodeHead(node)"></i>'+'<i class="normal" data-ng-hide="node.'+i+'.length"></i> '+'<span data-ng-class="node.selected" data-ng-click="'+n+'.selectNodeLabel(node)">{{node.'+c+"}}</span>"+'<div data-ng-hide="node.collapsed" data-tree-id="'+n+'" data-tree-model="node.'+i+'" data-node-id='+t+" data-node-label="+c+" data-node-children="+i+"></div>"+"</li>"+"</ul>";n&&o&&(a.angularTreeview&&(d[n]=d[n]||{},d[n].selectNodeHead=d[n].selectNodeHead||function(e){e.collapsed=!e.collapsed},d[n].selectNodeLabel=d[n].selectNodeLabel||function(e){d[n].currentNode&&d[n].currentNode.selected&&(d[n].currentNode.selected=void 0),"true"==r&&(e.selected="selected"),"true"==s&&(e.collapsed=!e.collapsed),d[n].currentNode=e}),l.html("").append(e(u)(d)))}}}])})(angular);


### PR DESCRIPTION
Added two new attributes to the html element/directive.  The first one, data-node-toggleclick, allows for the folder to expand and collapse when the label is clicked.  The second one, data-node-highlight, enables and disables the folder/node highlighting.  I also updated the readme with new sample code and a version bump.
